### PR TITLE
fix: registry-validate carried models, add music to fetch pipeline

### DIFF
--- a/apps/web/src/app/api/cron/fetch-avatar-pricing/route.ts
+++ b/apps/web/src/app/api/cron/fetch-avatar-pricing/route.ts
@@ -14,10 +14,11 @@ export async function GET(request: Request) {
   try {
     const result = await runAvatarFetch();
 
+    const hasUnvalidated = (result.totalUnvalidated ?? 0) > 0;
     const status =
-      result.errors.length === 0
+      result.errors.length === 0 && !hasUnvalidated
         ? 'success'
-        : result.totalModels > 0
+        : (result.totalModels > 0 || hasUnvalidated)
           ? 'partial'
           : 'failed';
 

--- a/apps/web/src/app/api/cron/fetch-image-pricing/route.ts
+++ b/apps/web/src/app/api/cron/fetch-image-pricing/route.ts
@@ -14,10 +14,11 @@ export async function GET(request: Request) {
   try {
     const result = await runImagePricingFetch();
 
+    const hasUnvalidated = (result.totalUnvalidated ?? 0) > 0;
     const status =
-      result.errors.length === 0
+      result.errors.length === 0 && !hasUnvalidated
         ? 'success'
-        : result.totalModels > 0
+        : (result.totalModels > 0 || hasUnvalidated)
           ? 'partial'
           : 'failed';
 

--- a/apps/web/src/app/api/cron/fetch-music-pricing/route.ts
+++ b/apps/web/src/app/api/cron/fetch-music-pricing/route.ts
@@ -14,10 +14,11 @@ export async function GET(request: Request) {
   try {
     const result = await runMusicFetch();
 
+    const hasUnvalidated = (result.totalUnvalidated ?? 0) > 0;
     const status =
-      result.errors.length === 0
+      result.errors.length === 0 && !hasUnvalidated
         ? 'success'
-        : result.totalModels > 0
+        : (result.totalModels > 0 || hasUnvalidated)
           ? 'partial'
           : 'failed';
 

--- a/apps/web/src/app/api/cron/fetch-pricing/route.ts
+++ b/apps/web/src/app/api/cron/fetch-pricing/route.ts
@@ -24,10 +24,11 @@ export async function GET(request: Request) {
   try {
     const result = await runPricingFetch();
 
+    const hasUnvalidated = (result.totalUnvalidated ?? 0) > 0;
     const status =
-      result.errors.length === 0
+      result.errors.length === 0 && !hasUnvalidated
         ? 'success'
-        : result.totalModels > 0
+        : (result.totalModels > 0 || hasUnvalidated)
           ? 'partial'
           : 'failed';
 

--- a/apps/web/src/app/api/cron/fetch-stt-pricing/route.ts
+++ b/apps/web/src/app/api/cron/fetch-stt-pricing/route.ts
@@ -14,10 +14,11 @@ export async function GET(request: Request) {
   try {
     const result = await runSttFetch();
 
+    const hasUnvalidated = (result.totalUnvalidated ?? 0) > 0;
     const status =
-      result.errors.length === 0
+      result.errors.length === 0 && !hasUnvalidated
         ? 'success'
-        : result.totalModels > 0
+        : (result.totalModels > 0 || hasUnvalidated)
           ? 'partial'
           : 'failed';
 

--- a/apps/web/src/app/api/cron/fetch-tts-pricing/route.ts
+++ b/apps/web/src/app/api/cron/fetch-tts-pricing/route.ts
@@ -14,10 +14,11 @@ export async function GET(request: Request) {
   try {
     const result = await runTtsFetch();
 
+    const hasUnvalidated = (result.totalUnvalidated ?? 0) > 0;
     const status =
-      result.errors.length === 0
+      result.errors.length === 0 && !hasUnvalidated
         ? 'success'
-        : result.totalModels > 0
+        : (result.totalModels > 0 || hasUnvalidated)
           ? 'partial'
           : 'failed';
 

--- a/apps/web/src/app/api/cron/fetch-video-pricing/route.ts
+++ b/apps/web/src/app/api/cron/fetch-video-pricing/route.ts
@@ -14,10 +14,11 @@ export async function GET(request: Request) {
   try {
     const result = await runVideoFetch();
 
+    const hasUnvalidated = (result.totalUnvalidated ?? 0) > 0;
     const status =
-      result.errors.length === 0
+      result.errors.length === 0 && !hasUnvalidated
         ? 'success'
-        : result.totalModels > 0
+        : (result.totalModels > 0 || hasUnvalidated)
           ? 'partial'
           : 'failed';
 

--- a/apps/web/src/app/api/cron/retry/route.ts
+++ b/apps/web/src/app/api/cron/retry/route.ts
@@ -111,10 +111,11 @@ export async function GET(request: Request) {
       console.log(`Retrying ${category} (${reason})...`);
       const result = await config.run(isRetryFlagged);
 
+      const hasUnvalidated = (result.totalUnvalidated ?? 0) > 0;
       const status =
-        result.errors.length === 0
+        result.errors.length === 0 && !hasUnvalidated
           ? 'success'
-          : result.totalModels > 0
+          : (result.totalModels > 0 || hasUnvalidated)
             ? 'partial'
             : 'failed';
 

--- a/apps/web/src/lib/fetcher/avatar-store.ts
+++ b/apps/web/src/lib/fetcher/avatar-store.ts
@@ -3,7 +3,7 @@ import { prisma } from '@/lib/prisma';
 import type { AvatarModelPricing, AvatarModelHistory, AvatarPriceHistoryPoint } from 'pricetoken';
 import { STATIC_AVATAR_PRICING } from 'pricetoken';
 import type { ExtractedAvatarModel } from './avatar-extractor';
-import { carrySource, findOriginalSnapshot } from './store';
+import { carrySource, findOriginalSnapshot, type RegistryValidationResult } from './store';
 import { computeConfidenceScore, confidenceLevelFromScore, computeFreshness } from '@/lib/confidence';
 
 export async function saveAvatarSnapshots(
@@ -57,6 +57,49 @@ export async function saveAvatarSnapshots(
 
   const result = await prisma.avatarPricingSnapshot.createMany({ data });
   return result.count;
+}
+
+export async function registryValidateCarriedAvatar(): Promise<RegistryValidationResult> {
+  const startOfDay = new Date(new Date().toISOString().split('T')[0] + 'T00:00:00Z');
+
+  const carriedSnapshots = await prisma.avatarPricingSnapshot.findMany({
+    where: { source: 'carried', createdAt: { gte: startOfDay } },
+    select: { id: true, modelId: true, costPerMinute: true },
+  });
+
+  if (carriedSnapshots.length === 0) return { validated: 0, unvalidated: 0 };
+
+  const registryByModel = new Map(
+    STATIC_AVATAR_PRICING.map((m) => [m.modelId, m])
+  );
+
+  const matchIds: string[] = [];
+  const mismatchIds: string[] = [];
+
+  for (const snap of carriedSnapshots) {
+    const reg = registryByModel.get(snap.modelId);
+    if (reg && reg.costPerMinute === snap.costPerMinute) {
+      matchIds.push(snap.id);
+    } else {
+      mismatchIds.push(snap.id);
+    }
+  }
+
+  if (matchIds.length > 0) {
+    await prisma.avatarPricingSnapshot.updateMany({
+      where: { id: { in: matchIds } },
+      data: { source: 'admin', confidence: 'high' },
+    });
+  }
+
+  if (mismatchIds.length > 0) {
+    await prisma.avatarPricingSnapshot.updateMany({
+      where: { id: { in: mismatchIds } },
+      data: { confidence: 'low' },
+    });
+  }
+
+  return { validated: matchIds.length, unvalidated: mismatchIds.length };
 }
 
 export async function getLatestAvatarPricing(provider?: string): Promise<AvatarModelPricing[]> {

--- a/apps/web/src/lib/fetcher/image-store.ts
+++ b/apps/web/src/lib/fetcher/image-store.ts
@@ -3,7 +3,7 @@ import { prisma } from '@/lib/prisma';
 import type { ImageModelPricing, ImageModelHistory, ImagePriceHistoryPoint } from 'pricetoken';
 import { STATIC_IMAGE_PRICING } from 'pricetoken';
 import { computeConfidenceScore, confidenceLevelFromScore, computeFreshness } from '@/lib/confidence';
-import { carrySource, findOriginalSnapshot } from './store';
+import { carrySource, findOriginalSnapshot, type RegistryValidationResult } from './store';
 
 export interface ExtractedImageModel {
   modelId: string;
@@ -297,6 +297,49 @@ export async function carryForwardMissingImages(): Promise<number> {
   if (data.length === 0) return 0;
   const result = await prisma.imagePricingSnapshot.createMany({ data });
   return result.count;
+}
+
+export async function registryValidateCarriedImages(): Promise<RegistryValidationResult> {
+  const startOfDay = new Date(new Date().toISOString().split('T')[0] + 'T00:00:00Z');
+
+  const carriedSnapshots = await prisma.imagePricingSnapshot.findMany({
+    where: { source: 'carried', createdAt: { gte: startOfDay } },
+    select: { id: true, modelId: true, pricePerImage: true },
+  });
+
+  if (carriedSnapshots.length === 0) return { validated: 0, unvalidated: 0 };
+
+  const registryByModel = new Map(
+    STATIC_IMAGE_PRICING.map((m) => [m.modelId, m])
+  );
+
+  const matchIds: string[] = [];
+  const mismatchIds: string[] = [];
+
+  for (const snap of carriedSnapshots) {
+    const reg = registryByModel.get(snap.modelId);
+    if (reg && reg.pricePerImage === snap.pricePerImage) {
+      matchIds.push(snap.id);
+    } else {
+      mismatchIds.push(snap.id);
+    }
+  }
+
+  if (matchIds.length > 0) {
+    await prisma.imagePricingSnapshot.updateMany({
+      where: { id: { in: matchIds } },
+      data: { source: 'admin', confidence: 'high' },
+    });
+  }
+
+  if (mismatchIds.length > 0) {
+    await prisma.imagePricingSnapshot.updateMany({
+      where: { id: { in: mismatchIds } },
+      data: { confidence: 'low' },
+    });
+  }
+
+  return { validated: matchIds.length, unvalidated: mismatchIds.length };
 }
 
 export async function getKnownImageModelIds(): Promise<Set<string>> {

--- a/apps/web/src/lib/fetcher/music-store.ts
+++ b/apps/web/src/lib/fetcher/music-store.ts
@@ -3,7 +3,7 @@ import { prisma } from '@/lib/prisma';
 import type { MusicModelPricing, MusicModelHistory, MusicPriceHistoryPoint } from 'pricetoken';
 import { STATIC_MUSIC_PRICING } from 'pricetoken';
 import type { ExtractedMusicModel } from './music-extractor';
-import { carrySource, findOriginalSnapshot } from './store';
+import { carrySource, findOriginalSnapshot, type RegistryValidationResult } from './store';
 import { computeConfidenceScore, confidenceLevelFromScore, computeFreshness } from '@/lib/confidence';
 
 export async function saveMusicSnapshots(
@@ -303,4 +303,47 @@ export async function carryForwardMissingMusic(): Promise<number> {
   if (data.length === 0) return 0;
   const result = await prisma.musicPricingSnapshot.createMany({ data });
   return result.count;
+}
+
+export async function registryValidateCarriedMusic(): Promise<RegistryValidationResult> {
+  const startOfDay = new Date(new Date().toISOString().split('T')[0] + 'T00:00:00Z');
+
+  const carriedSnapshots = await prisma.musicPricingSnapshot.findMany({
+    where: { source: 'carried', createdAt: { gte: startOfDay } },
+    select: { id: true, modelId: true, costPerMinute: true },
+  });
+
+  if (carriedSnapshots.length === 0) return { validated: 0, unvalidated: 0 };
+
+  const registryByModel = new Map(
+    STATIC_MUSIC_PRICING.map((m) => [m.modelId, m])
+  );
+
+  const matchIds: string[] = [];
+  const mismatchIds: string[] = [];
+
+  for (const snap of carriedSnapshots) {
+    const reg = registryByModel.get(snap.modelId);
+    if (reg && reg.costPerMinute === snap.costPerMinute) {
+      matchIds.push(snap.id);
+    } else {
+      mismatchIds.push(snap.id);
+    }
+  }
+
+  if (matchIds.length > 0) {
+    await prisma.musicPricingSnapshot.updateMany({
+      where: { id: { in: matchIds } },
+      data: { source: 'admin', confidence: 'high' },
+    });
+  }
+
+  if (mismatchIds.length > 0) {
+    await prisma.musicPricingSnapshot.updateMany({
+      where: { id: { in: mismatchIds } },
+      data: { confidence: 'low' },
+    });
+  }
+
+  return { validated: matchIds.length, unvalidated: mismatchIds.length };
 }

--- a/apps/web/src/lib/fetcher/run-avatar-fetch.ts
+++ b/apps/web/src/lib/fetcher/run-avatar-fetch.ts
@@ -6,6 +6,7 @@ import {
   saveAvatarSnapshots,
   seedAvatarFromStatic,
   carryForwardMissingAvatar,
+  registryValidateCarriedAvatar,
 } from './avatar-store';
 import { getLastFetchRun, saveFetchRun, type FetchWarning } from './store';
 import { avatarCrossVerify } from './avatar-cross-verify';
@@ -20,6 +21,7 @@ import type { AvatarVerificationResult } from './avatar-verification-types';
 export interface AvatarFetchResult {
   totalModels: number;
   totalFlagged: number;
+  totalUnvalidated: number;
   errors: string[];
   warnings: FetchWarning[];
   verificationResults: Map<string, AvatarVerificationResult>;
@@ -220,8 +222,13 @@ export async function runAvatarFetch(): Promise<AvatarFetchResult> {
     console.log(`Carried forward ${carried} avatar models with no new data today`);
   }
 
+  const { validated: regValidated, unvalidated: totalUnvalidated } = await registryValidateCarriedAvatar();
+  if (regValidated > 0 || totalUnvalidated > 0) {
+    console.log(`Registry validation: ${regValidated} validated, ${totalUnvalidated} unvalidated`);
+  }
+
   console.log(
-    `Avatar pricing fetch complete: ${totalModels} verified, ${totalFlagged} flagged, ${carried} carried, ${errors.length} errors, ${warnings.length} warnings`
+    `Avatar pricing fetch complete: ${totalModels} verified, ${totalFlagged} flagged, ${carried} carried (${regValidated} registry-validated), ${errors.length} errors, ${warnings.length} warnings`
   );
-  return { totalModels, totalFlagged, errors, warnings, verificationResults };
+  return { totalModels, totalFlagged, totalUnvalidated, errors, warnings, verificationResults };
 }

--- a/apps/web/src/lib/fetcher/run-fetch.ts
+++ b/apps/web/src/lib/fetcher/run-fetch.ts
@@ -7,6 +7,7 @@ import {
   getLastFetchRun,
   saveFetchRun,
   carryForwardMissing,
+  registryValidateCarried,
   getKnownModelIds,
   type FetchWarning,
 } from './store';
@@ -24,6 +25,7 @@ import type { VerificationResult } from './verification-types';
 export interface FetchResult {
   totalModels: number;
   totalFlagged: number;
+  totalUnvalidated: number;
   errors: string[];
   warnings: FetchWarning[];
   verificationResults: Map<string, VerificationResult>;
@@ -260,8 +262,14 @@ export async function runPricingFetch(options: FetchOptions = {}): Promise<Fetch
     console.log(`Carried forward ${carried} models with no new data today`);
   }
 
+  // Validate carried models against YAML registry
+  const { validated: regValidated, unvalidated: totalUnvalidated } = await registryValidateCarried();
+  if (regValidated > 0 || totalUnvalidated > 0) {
+    console.log(`Registry validation: ${regValidated} validated, ${totalUnvalidated} unvalidated`);
+  }
+
   console.log(
-    `Pricing fetch complete: ${totalModels} verified, ${totalFlagged} flagged, ${carried} carried, ${errors.length} errors, ${warnings.length} warnings`
+    `Pricing fetch complete: ${totalModels} verified, ${totalFlagged} flagged, ${carried} carried (${regValidated} registry-validated), ${errors.length} errors, ${warnings.length} warnings`
   );
-  return { totalModels, totalFlagged, errors, warnings, verificationResults };
+  return { totalModels, totalFlagged, totalUnvalidated, errors, warnings, verificationResults };
 }

--- a/apps/web/src/lib/fetcher/run-image-fetch.ts
+++ b/apps/web/src/lib/fetcher/run-image-fetch.ts
@@ -5,6 +5,7 @@ import {
   saveImageSnapshots,
   seedImageFromStatic,
   carryForwardMissingImages,
+  registryValidateCarriedImages,
   getKnownImageModelIds,
 } from './image-store';
 import { saveFetchRun, getLastFetchRun, type FetchWarning } from './store';
@@ -22,6 +23,7 @@ import type { FetchOptions } from './run-fetch';
 export interface ImageFetchResult {
   totalModels: number;
   totalFlagged: number;
+  totalUnvalidated: number;
   errors: string[];
   warnings: FetchWarning[];
   verificationResults: Map<string, ImageVerificationResult>;
@@ -266,8 +268,13 @@ export async function runImagePricingFetch(options: FetchOptions = {}): Promise<
     console.log(`Carried forward ${carried} image models not seen in this run`);
   }
 
+  const { validated: regValidated, unvalidated: totalUnvalidated } = await registryValidateCarriedImages();
+  if (regValidated > 0 || totalUnvalidated > 0) {
+    console.log(`Registry validation: ${regValidated} validated, ${totalUnvalidated} unvalidated`);
+  }
+
   console.log(
-    `Image pricing fetch complete: ${totalModels} verified, ${totalFlagged} flagged, ${carried} carried, ${errors.length} errors, ${warnings.length} warnings`
+    `Image pricing fetch complete: ${totalModels} verified, ${totalFlagged} flagged, ${carried} carried (${regValidated} registry-validated), ${errors.length} errors, ${warnings.length} warnings`
   );
-  return { totalModels, totalFlagged, errors, warnings, verificationResults };
+  return { totalModels, totalFlagged, totalUnvalidated, errors, warnings, verificationResults };
 }

--- a/apps/web/src/lib/fetcher/run-music-fetch.ts
+++ b/apps/web/src/lib/fetcher/run-music-fetch.ts
@@ -6,6 +6,7 @@ import {
   saveMusicSnapshots,
   seedMusicFromStatic,
   carryForwardMissingMusic,
+  registryValidateCarriedMusic,
 } from './music-store';
 import { getLastFetchRun, saveFetchRun, type FetchWarning } from './store';
 import { musicCrossVerify } from './music-cross-verify';
@@ -20,6 +21,7 @@ import type { MusicVerificationResult } from './music-verification-types';
 export interface MusicFetchResult {
   totalModels: number;
   totalFlagged: number;
+  totalUnvalidated: number;
   errors: string[];
   warnings: FetchWarning[];
   verificationResults: Map<string, MusicVerificationResult>;
@@ -220,8 +222,13 @@ export async function runMusicFetch(): Promise<MusicFetchResult> {
     console.log(`Carried forward ${carried} music models with no new data today`);
   }
 
+  const { validated: regValidated, unvalidated: totalUnvalidated } = await registryValidateCarriedMusic();
+  if (regValidated > 0 || totalUnvalidated > 0) {
+    console.log(`Registry validation: ${regValidated} validated, ${totalUnvalidated} unvalidated`);
+  }
+
   console.log(
-    `Music pricing fetch complete: ${totalModels} verified, ${totalFlagged} flagged, ${carried} carried, ${errors.length} errors, ${warnings.length} warnings`
+    `Music pricing fetch complete: ${totalModels} verified, ${totalFlagged} flagged, ${carried} carried (${regValidated} registry-validated), ${errors.length} errors, ${warnings.length} warnings`
   );
-  return { totalModels, totalFlagged, errors, warnings, verificationResults };
+  return { totalModels, totalFlagged, totalUnvalidated, errors, warnings, verificationResults };
 }

--- a/apps/web/src/lib/fetcher/run-stt-fetch.ts
+++ b/apps/web/src/lib/fetcher/run-stt-fetch.ts
@@ -6,6 +6,7 @@ import {
   saveSttSnapshots,
   seedSttFromStatic,
   carryForwardMissingStt,
+  registryValidateCarriedStt,
 } from './stt-store';
 import { getLastFetchRun, saveFetchRun, type FetchWarning } from './store';
 import { sttCrossVerify } from './stt-cross-verify';
@@ -20,6 +21,7 @@ import type { SttVerificationResult } from './stt-verification-types';
 export interface SttFetchResult {
   totalModels: number;
   totalFlagged: number;
+  totalUnvalidated: number;
   errors: string[];
   warnings: FetchWarning[];
   verificationResults: Map<string, SttVerificationResult>;
@@ -220,8 +222,13 @@ export async function runSttFetch(): Promise<SttFetchResult> {
     console.log(`Carried forward ${carried} STT models with no new data today`);
   }
 
+  const { validated: regValidated, unvalidated: totalUnvalidated } = await registryValidateCarriedStt();
+  if (regValidated > 0 || totalUnvalidated > 0) {
+    console.log(`Registry validation: ${regValidated} validated, ${totalUnvalidated} unvalidated`);
+  }
+
   console.log(
-    `STT pricing fetch complete: ${totalModels} verified, ${totalFlagged} flagged, ${carried} carried, ${errors.length} errors, ${warnings.length} warnings`
+    `STT pricing fetch complete: ${totalModels} verified, ${totalFlagged} flagged, ${carried} carried (${regValidated} registry-validated), ${errors.length} errors, ${warnings.length} warnings`
   );
-  return { totalModels, totalFlagged, errors, warnings, verificationResults };
+  return { totalModels, totalFlagged, totalUnvalidated, errors, warnings, verificationResults };
 }

--- a/apps/web/src/lib/fetcher/run-tts-fetch.ts
+++ b/apps/web/src/lib/fetcher/run-tts-fetch.ts
@@ -6,6 +6,7 @@ import {
   saveTtsSnapshots,
   seedTtsFromStatic,
   carryForwardMissingTts,
+  registryValidateCarriedTts,
 } from './tts-store';
 import { getLastFetchRun, saveFetchRun, type FetchWarning } from './store';
 import { ttsCrossVerify } from './tts-cross-verify';
@@ -20,6 +21,7 @@ import type { TtsVerificationResult } from './tts-verification-types';
 export interface TtsFetchResult {
   totalModels: number;
   totalFlagged: number;
+  totalUnvalidated: number;
   errors: string[];
   warnings: FetchWarning[];
   verificationResults: Map<string, TtsVerificationResult>;
@@ -243,8 +245,13 @@ export async function runTtsFetch(): Promise<TtsFetchResult> {
     console.log(`Carried forward ${carried} TTS models with no new data today`);
   }
 
+  const { validated: regValidated, unvalidated: totalUnvalidated } = await registryValidateCarriedTts();
+  if (regValidated > 0 || totalUnvalidated > 0) {
+    console.log(`Registry validation: ${regValidated} validated, ${totalUnvalidated} unvalidated`);
+  }
+
   console.log(
-    `TTS pricing fetch complete: ${totalModels} verified, ${totalFlagged} flagged, ${carried} carried, ${errors.length} errors, ${warnings.length} warnings`
+    `TTS pricing fetch complete: ${totalModels} verified, ${totalFlagged} flagged, ${carried} carried (${regValidated} registry-validated), ${errors.length} errors, ${warnings.length} warnings`
   );
-  return { totalModels, totalFlagged, errors, warnings, verificationResults };
+  return { totalModels, totalFlagged, totalUnvalidated, errors, warnings, verificationResults };
 }

--- a/apps/web/src/lib/fetcher/run-video-fetch.ts
+++ b/apps/web/src/lib/fetcher/run-video-fetch.ts
@@ -6,6 +6,7 @@ import {
   saveVideoSnapshots,
   seedVideoFromStatic,
   carryForwardMissingVideo,
+  registryValidateCarriedVideo,
   getKnownVideoModelIds,
 } from './video-store';
 import { getLastFetchRun, saveFetchRun, type FetchWarning } from './store';
@@ -23,6 +24,7 @@ import type { FetchOptions } from './run-fetch';
 export interface VideoFetchResult {
   totalModels: number;
   totalFlagged: number;
+  totalUnvalidated: number;
   errors: string[];
   warnings: FetchWarning[];
   verificationResults: Map<string, VideoVerificationResult>;
@@ -266,8 +268,13 @@ export async function runVideoFetch(options: FetchOptions = {}): Promise<VideoFe
     console.log(`Carried forward ${carried} video models with no new data today`);
   }
 
+  const { validated: regValidated, unvalidated: totalUnvalidated } = await registryValidateCarriedVideo();
+  if (regValidated > 0 || totalUnvalidated > 0) {
+    console.log(`Registry validation: ${regValidated} validated, ${totalUnvalidated} unvalidated`);
+  }
+
   console.log(
-    `Video pricing fetch complete: ${totalModels} verified, ${totalFlagged} flagged, ${carried} carried, ${errors.length} errors, ${warnings.length} warnings`
+    `Video pricing fetch complete: ${totalModels} verified, ${totalFlagged} flagged, ${carried} carried (${regValidated} registry-validated), ${errors.length} errors, ${warnings.length} warnings`
   );
-  return { totalModels, totalFlagged, errors, warnings, verificationResults };
+  return { totalModels, totalFlagged, totalUnvalidated, errors, warnings, verificationResults };
 }

--- a/apps/web/src/lib/fetcher/store.ts
+++ b/apps/web/src/lib/fetcher/store.ts
@@ -38,6 +38,11 @@ export function carrySource(
   return trusted && recent ? effectiveSource : 'carried';
 }
 
+export interface RegistryValidationResult {
+  validated: number;
+  unvalidated: number;
+}
+
 export interface FetchWarning {
   type: 'models_missing' | 'low_confidence' | 'extraction_error' | 'sanity_check_failed';
   provider: string;
@@ -368,6 +373,52 @@ export async function saveFetchRun(
   return prisma.fetchRunLog.create({
     data: { provider, modelsFound, modelsMissing, modelsNew, totalExtracted, error },
   });
+}
+
+/** Validate today's carried snapshots against the YAML registry.
+ *  Matches → upgrade to source='admin', confidence='high'.
+ *  Mismatches or not in registry → downgrade to confidence='low'. */
+export async function registryValidateCarried(): Promise<RegistryValidationResult> {
+  const startOfDay = new Date(new Date().toISOString().split('T')[0] + 'T00:00:00Z');
+
+  const carriedSnapshots = await prisma.modelPricingSnapshot.findMany({
+    where: { source: 'carried', createdAt: { gte: startOfDay } },
+    select: { id: true, modelId: true, inputPerMTok: true, outputPerMTok: true },
+  });
+
+  if (carriedSnapshots.length === 0) return { validated: 0, unvalidated: 0 };
+
+  const registryByModel = new Map(
+    STATIC_PRICING.map((m) => [m.modelId, m])
+  );
+
+  const matchIds: string[] = [];
+  const mismatchIds: string[] = [];
+
+  for (const snap of carriedSnapshots) {
+    const reg = registryByModel.get(snap.modelId);
+    if (reg && reg.inputPerMTok === snap.inputPerMTok && reg.outputPerMTok === snap.outputPerMTok) {
+      matchIds.push(snap.id);
+    } else {
+      mismatchIds.push(snap.id);
+    }
+  }
+
+  if (matchIds.length > 0) {
+    await prisma.modelPricingSnapshot.updateMany({
+      where: { id: { in: matchIds } },
+      data: { source: 'admin', confidence: 'high' },
+    });
+  }
+
+  if (mismatchIds.length > 0) {
+    await prisma.modelPricingSnapshot.updateMany({
+      where: { id: { in: mismatchIds } },
+      data: { confidence: 'low' },
+    });
+  }
+
+  return { validated: matchIds.length, unvalidated: mismatchIds.length };
 }
 
 export async function getRecentWarnings(days = 7): Promise<FetchWarning[]> {

--- a/apps/web/src/lib/fetcher/stt-store.ts
+++ b/apps/web/src/lib/fetcher/stt-store.ts
@@ -1,9 +1,10 @@
 import { Prisma } from '@prisma/client';
 import { prisma } from '@/lib/prisma';
 import type { SttModelPricing, SttModelHistory, SttPriceHistoryPoint } from 'pricetoken';
+import { STATIC_STT_PRICING } from 'pricetoken';
 import type { ExtractedSttModel } from './stt-extractor';
 import { computeConfidenceScore, confidenceLevelFromScore, computeFreshness } from '@/lib/confidence';
-import { carrySource, findOriginalSnapshot } from './store';
+import { carrySource, findOriginalSnapshot, type RegistryValidationResult } from './store';
 
 export async function saveSttSnapshots(
   provider: string,
@@ -274,4 +275,47 @@ export async function carryForwardMissingStt(): Promise<number> {
   if (data.length === 0) return 0;
   const result = await prisma.sttPricingSnapshot.createMany({ data });
   return result.count;
+}
+
+export async function registryValidateCarriedStt(): Promise<RegistryValidationResult> {
+  const startOfDay = new Date(new Date().toISOString().split('T')[0] + 'T00:00:00Z');
+
+  const carriedSnapshots = await prisma.sttPricingSnapshot.findMany({
+    where: { source: 'carried', createdAt: { gte: startOfDay } },
+    select: { id: true, modelId: true, costPerMinute: true },
+  });
+
+  if (carriedSnapshots.length === 0) return { validated: 0, unvalidated: 0 };
+
+  const registryByModel = new Map(
+    STATIC_STT_PRICING.map((m) => [m.modelId, m])
+  );
+
+  const matchIds: string[] = [];
+  const mismatchIds: string[] = [];
+
+  for (const snap of carriedSnapshots) {
+    const reg = registryByModel.get(snap.modelId);
+    if (reg && reg.costPerMinute === snap.costPerMinute) {
+      matchIds.push(snap.id);
+    } else {
+      mismatchIds.push(snap.id);
+    }
+  }
+
+  if (matchIds.length > 0) {
+    await prisma.sttPricingSnapshot.updateMany({
+      where: { id: { in: matchIds } },
+      data: { source: 'admin', confidence: 'high' },
+    });
+  }
+
+  if (mismatchIds.length > 0) {
+    await prisma.sttPricingSnapshot.updateMany({
+      where: { id: { in: mismatchIds } },
+      data: { confidence: 'low' },
+    });
+  }
+
+  return { validated: matchIds.length, unvalidated: mismatchIds.length };
 }

--- a/apps/web/src/lib/fetcher/tts-store.ts
+++ b/apps/web/src/lib/fetcher/tts-store.ts
@@ -1,9 +1,10 @@
 import { Prisma } from '@prisma/client';
 import { prisma } from '@/lib/prisma';
 import type { TtsModelPricing, TtsModelHistory, TtsPriceHistoryPoint } from 'pricetoken';
+import { STATIC_TTS_PRICING } from 'pricetoken';
 import type { ExtractedTtsModel } from './tts-extractor';
 import { computeConfidenceScore, confidenceLevelFromScore, computeFreshness } from '@/lib/confidence';
-import { carrySource, findOriginalSnapshot } from './store';
+import { carrySource, findOriginalSnapshot, type RegistryValidationResult } from './store';
 
 export async function saveTtsSnapshots(
   provider: string,
@@ -274,4 +275,47 @@ export async function carryForwardMissingTts(): Promise<number> {
   if (data.length === 0) return 0;
   const result = await prisma.ttsPricingSnapshot.createMany({ data });
   return result.count;
+}
+
+export async function registryValidateCarriedTts(): Promise<RegistryValidationResult> {
+  const startOfDay = new Date(new Date().toISOString().split('T')[0] + 'T00:00:00Z');
+
+  const carriedSnapshots = await prisma.ttsPricingSnapshot.findMany({
+    where: { source: 'carried', createdAt: { gte: startOfDay } },
+    select: { id: true, modelId: true, costPerMChars: true },
+  });
+
+  if (carriedSnapshots.length === 0) return { validated: 0, unvalidated: 0 };
+
+  const registryByModel = new Map(
+    STATIC_TTS_PRICING.map((m) => [m.modelId, m])
+  );
+
+  const matchIds: string[] = [];
+  const mismatchIds: string[] = [];
+
+  for (const snap of carriedSnapshots) {
+    const reg = registryByModel.get(snap.modelId);
+    if (reg && reg.costPerMChars === snap.costPerMChars) {
+      matchIds.push(snap.id);
+    } else {
+      mismatchIds.push(snap.id);
+    }
+  }
+
+  if (matchIds.length > 0) {
+    await prisma.ttsPricingSnapshot.updateMany({
+      where: { id: { in: matchIds } },
+      data: { source: 'admin', confidence: 'high' },
+    });
+  }
+
+  if (mismatchIds.length > 0) {
+    await prisma.ttsPricingSnapshot.updateMany({
+      where: { id: { in: mismatchIds } },
+      data: { confidence: 'low' },
+    });
+  }
+
+  return { validated: matchIds.length, unvalidated: mismatchIds.length };
 }

--- a/apps/web/src/lib/fetcher/video-store.ts
+++ b/apps/web/src/lib/fetcher/video-store.ts
@@ -3,7 +3,7 @@ import { prisma } from '@/lib/prisma';
 import type { VideoModelPricing, VideoModelHistory, VideoPriceHistoryPoint } from 'pricetoken';
 import { STATIC_VIDEO_PRICING } from 'pricetoken';
 import type { ExtractedVideoModel } from './video-extractor';
-import { carrySource, findOriginalSnapshot } from './store';
+import { carrySource, findOriginalSnapshot, type RegistryValidationResult } from './store';
 import { computeConfidenceScore, confidenceLevelFromScore, computeFreshness } from '@/lib/confidence';
 
 export async function saveVideoSnapshots(
@@ -288,6 +288,49 @@ export async function carryForwardMissingVideo(): Promise<number> {
   if (data.length === 0) return 0;
   const result = await prisma.videoPricingSnapshot.createMany({ data });
   return result.count;
+}
+
+export async function registryValidateCarriedVideo(): Promise<RegistryValidationResult> {
+  const startOfDay = new Date(new Date().toISOString().split('T')[0] + 'T00:00:00Z');
+
+  const carriedSnapshots = await prisma.videoPricingSnapshot.findMany({
+    where: { source: 'carried', createdAt: { gte: startOfDay } },
+    select: { id: true, modelId: true, costPerMinute: true },
+  });
+
+  if (carriedSnapshots.length === 0) return { validated: 0, unvalidated: 0 };
+
+  const registryByModel = new Map(
+    STATIC_VIDEO_PRICING.map((m) => [m.modelId, m])
+  );
+
+  const matchIds: string[] = [];
+  const mismatchIds: string[] = [];
+
+  for (const snap of carriedSnapshots) {
+    const reg = registryByModel.get(snap.modelId);
+    if (reg && reg.costPerMinute === snap.costPerMinute) {
+      matchIds.push(snap.id);
+    } else {
+      mismatchIds.push(snap.id);
+    }
+  }
+
+  if (matchIds.length > 0) {
+    await prisma.videoPricingSnapshot.updateMany({
+      where: { id: { in: matchIds } },
+      data: { source: 'admin', confidence: 'high' },
+    });
+  }
+
+  if (mismatchIds.length > 0) {
+    await prisma.videoPricingSnapshot.updateMany({
+      where: { id: { in: mismatchIds } },
+      data: { confidence: 'low' },
+    });
+  }
+
+  return { validated: matchIds.length, unvalidated: mismatchIds.length };
 }
 
 export async function getKnownVideoModelIds(): Promise<Set<string>> {

--- a/infra/fetch-all-pricing.sh
+++ b/infra/fetch-all-pricing.sh
@@ -16,6 +16,7 @@ CATEGORIES=(
   "fetch-video-pricing"
   "fetch-stt-pricing"
   "fetch-tts-pricing"
+  "fetch-music-pricing"
 )
 
 run_category() {


### PR DESCRIPTION
## Summary

- **Registry validation step** added to all 7 category fetch pipelines. After carry-forward, carried models are validated against the YAML registry -- matches upgraded to source=admin with high confidence, mismatches downgraded to low confidence
- **Music added to infra/fetch-all-pricing.sh** -- was missing from Pass 1, only covered by retry
- **Status determination updated** across all cron routes + retry route -- runs with unvalidated models marked partial instead of success, triggering retry

## Why

Many models had source=carried with agentApprovals=null -- seeded from static data and carried forward daily without verification. The scraper did not find them on provider pages, and the carry mechanism silently preserved them with no validation.

## Test plan

- [x] npm run ci passes (lint + typecheck + test + build + python)
- [ ] Deploy and trigger fetch-all-pricing.sh -- verify music runs in Pass 1
- [ ] Check DB after run: carried models matching registry should be source=admin
- [ ] Verify retry endpoint re-runs categories with unvalidated models