### PR TITLE
fix: seed all 6 categories on deploy

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -118,6 +118,10 @@ jobs:
             echo "Seeding new models..."
             docker compose -f docker-compose.prod.yml exec web npx tsx scripts/seed.ts
             docker compose -f docker-compose.prod.yml exec web npx tsx scripts/seed-video.ts
+            docker compose -f docker-compose.prod.yml exec web npx tsx scripts/seed-avatar.ts
+            docker compose -f docker-compose.prod.yml exec web npx tsx scripts/seed-tts.ts
+            docker compose -f docker-compose.prod.yml exec web npx tsx scripts/seed-stt.ts
+            docker compose -f docker-compose.prod.yml exec web npx tsx scripts/seed-music.ts
 
             echo "Syncing systemd timer..."
             chmod +x ~/pricetoken/infra/fetch-all-pricing.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -71,11 +71,17 @@ COPY --from=builder --chown=node:node /app/packages/sdk/src/static.ts ./packages
 COPY --from=builder --chown=node:node /app/packages/sdk/src/static-image.ts ./packages/sdk/src/static-image.ts
 COPY --from=builder --chown=node:node /app/packages/sdk/src/video-static.ts ./packages/sdk/src/video-static.ts
 COPY --from=builder --chown=node:node /app/packages/sdk/src/avatar-static.ts ./packages/sdk/src/avatar-static.ts
+COPY --from=builder --chown=node:node /app/packages/sdk/src/tts-static.ts ./packages/sdk/src/tts-static.ts
+COPY --from=builder --chown=node:node /app/packages/sdk/src/stt-static.ts ./packages/sdk/src/stt-static.ts
+COPY --from=builder --chown=node:node /app/packages/sdk/src/music-static.ts ./packages/sdk/src/music-static.ts
 COPY --from=builder --chown=node:node /app/packages/sdk/src/types.ts ./packages/sdk/src/types.ts
 COPY --chown=node:node scripts/seed.ts ./scripts/seed.ts
 COPY --chown=node:node scripts/seed-video.ts ./scripts/seed-video.ts
 COPY --chown=node:node scripts/video-corrections.ts ./scripts/video-corrections.ts
 COPY --chown=node:node scripts/seed-avatar.ts ./scripts/seed-avatar.ts
+COPY --chown=node:node scripts/seed-tts.ts ./scripts/seed-tts.ts
+COPY --chown=node:node scripts/seed-stt.ts ./scripts/seed-stt.ts
+COPY --chown=node:node scripts/seed-music.ts ./scripts/seed-music.ts
 COPY --chown=node:node tsconfig.base.json ./tsconfig.base.json
 COPY --chown=node:node packages/sdk/tsconfig.json ./packages/sdk/tsconfig.json
 


### PR DESCRIPTION
## Summary

- Dockerfile: add missing static files (tts, stt, music) and seed scripts (tts, stt, music)
- deploy.yml: run all 6 seed scripts instead of just text + video

Deploy was only seeding text and video models. Avatar, TTS, STT, and music models added to the registry were never inserted into the DB on deploy.

## Test plan

- [x] Verified FAL LTX avatar model was missing from prod DB due to this gap
- [ ] Deploy should seed all categories and log counts for each